### PR TITLE
SEC-232 fix(security): Replace compromised tj-actions/changed-files w…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: step-security/changed-files@v45
 
       - name: Check changed files
         run: |

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -19,14 +19,14 @@ jobs:
 
     - name: Get changed icons
       id: changed-icons
-      uses: tj-actions/changed-files@v41
+      uses: step-security/changed-files@v45
       with:
         files: _data/icons/*.json
         base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
     
     - name: Get changed icon blobs
       id: changed-icon-blobs
-      uses: tj-actions/changed-files@v41
+      uses: step-security/changed-files@v45
       with:
         files: _data/iconsDownload/*
         base_sha: ${{ steps.last_successful_commit_push.outputs.base }}
@@ -121,7 +121,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v41
+      uses: step-security/changed-files@v45
       with:
         files: _data/*/*.json
         base_sha: ${{ steps.last_successful_commit_push.outputs.base }}


### PR DESCRIPTION
This pull request addresses the security vulnerability identified in the `tj-actions/changed-files` GitHub Action, tracked as CVE-2025-30066. The compromised action was found to leak secrets in logs due to a supply chain attack.

**Changes Implemented:**
- Replaced the compromised tj-actions/changed-files action with the secure alternative step-security/changed-files@v45 in the workflow file .github/workflows/check-changed-files.yml.

**Rationale**:

The step-security/changed-files action serves as a free, secure, drop-in replacement for the compromised action, mitigating the risk associated with CVE-2025-30066.

**Additional Information**
[Wiz.io GitHub Action tj-actions/changed-files supply chain attack: everything you need to know](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066)
[Step-Security Harden-Runner detection: tj-actions/changed-files action is compromised](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)
